### PR TITLE
fix crashes in apparel overrides, body addons, and xml loading

### DIFF
--- a/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.cs
+++ b/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.cs
@@ -101,7 +101,8 @@ namespace AlienRace
                 if (variantCounting <= 0)
                     variantCounting = 1;
                 
-                savedIndex ??= this.linkVariantIndexWithPrevious ? sharedIndex % this.VariantCountMax : Rand.Range(0, this.VariantCountMax);
+                int maxVariants = Mathf.Max(1, this.VariantCountMax);
+                savedIndex ??= this.linkVariantIndexWithPrevious ? sharedIndex % maxVariants : Rand.Range(0, maxVariants);
 
                 sharedIndex = savedIndex.Value;
 

--- a/Source/AlienRace/AlienRace/AlienPartGenerator.Graphics.cs
+++ b/Source/AlienRace/AlienRace/AlienPartGenerator.Graphics.cs
@@ -20,7 +20,7 @@ public partial class AlienPartGenerator
                 XmlDocument xmlDoc = new();
 
                 StringBuilder xmlRaw = new("<root>");
-                if (xmlRoot.Value == null && xmlRoot.FirstChild.Name != nameof(this.path))
+                if (xmlRoot.Value == null && xmlRoot.FirstChild != null && xmlRoot.FirstChild.Name != nameof(this.path))
                     xmlRaw.Append($"<path>{xmlRoot.FirstChild.Value}</path>");
 
                 xmlRaw.Append($"<conditions><{xmlRoot.LocalName}>{xmlRoot.Attributes!["For"].Value}</{xmlRoot.LocalName}></conditions></root>");

--- a/Source/AlienRace/AlienRace/ApparelGraphics/ApparelGraphicsOverrides.cs
+++ b/Source/AlienRace/AlienRace/ApparelGraphics/ApparelGraphicsOverrides.cs
@@ -62,7 +62,7 @@ namespace AlienRace.ApparelGraphics
 
         public AlienPartGenerator.ExtendedGraphicTop GetGraphics(ThingDef apparelDef) =>
             !this.wornGraphicPaths.NullOrEmpty() ?
-                this.wornGraphicPaths[apparelDef.GetHashCode() % this.wornGraphicPaths.Count] :
+                this.wornGraphicPaths[System.Math.Abs(apparelDef.GetHashCode() % this.wornGraphicPaths.Count)] :
                 this.wornGraphicPath;
 
         public bool IsSuitableReplacementFor(ThingDef apparelDef)

--- a/Source/AlienRace/AlienRace/ExtendedGraphics/AbstractExtendedGraphic.cs
+++ b/Source/AlienRace/AlienRace/ExtendedGraphics/AbstractExtendedGraphic.cs
@@ -116,6 +116,8 @@ public abstract class AbstractExtendedGraphic : IExtendedGraphic
                 //Log.Message("Original: " + childNode.OuterXml);
                 foreach (XmlNode graphicNode in childNode.ChildNodes)
                 {
+                    if (graphicNode.NodeType != XmlNodeType.Element) continue;
+
                     XmlAttribute attribute2 = xmlRoot.OwnerDocument!.CreateAttribute("For");
                     attribute2.Value = graphicNode.Name;
                     graphicNode.Attributes!.SetNamedItem(attribute2);
@@ -137,7 +139,7 @@ public abstract class AbstractExtendedGraphic : IExtendedGraphic
     public static XmlNode CustomListLoader(XmlNode xmlNode)
     {
         foreach (XmlNode graphicNode in xmlNode.ChildNodes)
-            if (graphicNode.Attributes!["Class"] == null)
+            if (graphicNode.NodeType == XmlNodeType.Element && graphicNode.Attributes!["Class"] == null)
             {
                 XmlAttribute attribute = xmlNode.OwnerDocument!.CreateAttribute("Class");
                 attribute.Value = typeof(AlienPartGenerator.ExtendedConditionGraphic).FullName;

--- a/Source/AlienRace/AlienRace/Utilities.cs
+++ b/Source/AlienRace/AlienRace/Utilities.cs
@@ -111,7 +111,7 @@
         {
             Traverse traverse = Traverse.Create(wanter);
             foreach (XmlNode xmlNode in xmlRootNode.ChildNodes)
-                if (!excludedFieldNames.Contains(xmlNode.Name))
+                if (xmlNode.NodeType == XmlNodeType.Element && !excludedFieldNames.Contains(xmlNode.Name))
                     SetFieldFromXmlNode(traverse, xmlNode, wanter, xmlNode.Name);
         }
 


### PR DESCRIPTION
- fixed negative array index crash in apparel graphic overrides when def hashcode is negative
- fixed divide by zero crash in body addon path resolution when variant count is zero
- added null and element type checks in XML custom loaders to prevent crashes when XML comments or empty nodes are present